### PR TITLE
Add support for leaflet-side-by-side

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ dist/
 build/
 *.py[cod]
 node_modules/
+venv/*
 
 # Compiled javascript
 ipyleaflet/static/

--- a/README.md
+++ b/README.md
@@ -42,4 +42,6 @@ Note for developers: the `--symlink` argument on Linux or OS X allows one to
 modify the JavaScript code in-place. This feature is not available
 with Windows.
 
-
+`./scripts/update` will handle creating (and updating) a virtualenv for you,
+installing dependencies, installing ipyleaflet, and enabling all relevant
+notebook extensions.

--- a/examples/Side-by-side.ipynb
+++ b/examples/Side-by-side.ipynb
@@ -1,0 +1,83 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Side-by-Side\n",
+    "\n",
+    "This example shows how to use the [Leaflet side-by-side](https://github.com/digidem/leaflet-side-by-side) slider with ipyleaflet."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "from ipyleaflet import (\n",
+    "    Map, TileLayer, SideBySideControl\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "center = [34.6252978589571, -77.34580993652344]\n",
+    "zoom = 10"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m = Map(center=center, zoom=zoom)\n",
+    "m"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "left = TileLayer(url='https://cartodb-basemaps-{s}.global.ssl.fastly.net/light_all/{z}/{x}/{y}.png')\n",
+    "right = TileLayer(url='https://cartodb-basemaps-{s}.global.ssl.fastly.net/dark_all/{z}/{x}/{y}.png')\n",
+    "control = SideBySideControl(leftLayer=left, rightLayer=right)\n",
+    "m.add_control(control)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/ipyleaflet/leaflet.py
+++ b/ipyleaflet/leaflet.py
@@ -287,6 +287,32 @@ class Control(Widget):
                     self._map.remove_control(self)
 
 
+class SideBySideControl(Control):
+    _view_name = Unicode('LeafletSideBySideControlView').tag(sync=True)
+    _model_name = Unicode('LeafletSideBySideControlModel').tag(sync=True)
+    _draw_callbacks = Instance(CallbackDispatcher, ())
+
+    leftLayer = Instance(TileLayer).tag(sync=True, **widget_serialization)
+    rightLayer = Instance(TileLayer).tag(sync=True, **widget_serialization)
+
+    @default('leftLayer')
+    def _default_leftLayer(self):
+        return TileLayer()
+
+    @default('rightLayer')
+    def _default_rightLayer(self):
+        return TileLayer()
+
+    def __init__(self, **kwargs):
+        super(SideBySideControl, self).__init__(**kwargs)
+        self.on_msg(self._handle_leaflet_event)
+
+    def _handle_leaflet_event(self, _, content, buffers):
+        if content.get('event', '') == 'dividermove':
+            event = content.get('event')
+            self.x = event.x
+
+
 class DrawControl(Control):
     _view_name = Unicode('LeafletDrawControlView').tag(sync=True)
     _model_name = Unicode('LeafletDrawControlModel').tag(sync=True)

--- a/js/package.json
+++ b/js/package.json
@@ -25,6 +25,7 @@
     "jupyter-js-widgets": "3.0.0-alpha.2",
     "leaflet": "^0.7.7",
     "leaflet-draw": "^0.3.0",
+    "leaflet-side-by-side": "^2.0.0",
     "underscore": "^1.8.3"
   }
 }

--- a/scripts/update
+++ b/scripts/update
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -e
+
+# Get rid of old install maybe
+if [ -d venv ]; then
+    rm -r venv
+fi
+
+# Reset / grab a new one
+virtualenv venv
+source venv/bin/activate
+pip install jupyter notebook
+jupyter nbextension enable --py --sys-prefix widgetsnbextension
+
+# Install local files
+pip install -e .
+jupyter nbextension install --py --symlink --sys-prefix ipyleaflet
+jupyter nbextension enable --py --sys-prefix ipyleaflet


### PR DESCRIPTION
Overview
------

This PR adds support for a leaflet-side-by-side control.

Checklist

- [x] example included

Testing
------

- `./scripts/update`
- `source venv/bin/activate(.fish)`
- `jupyter notebook`
- open `Side-by-side.ipynb` and run it

Notes
------

Some things are easier than others. As it stands, you can _add_ a side-by-side control, but that's it, forever. 
It isn't super obvious to me at this point how the draw control understands that it needs to die when you tell the map to delete it in the draw example notebook.

Closes #3 