### PR TITLE
Bump version and rename

### DIFF
--- a/ipyleaflet/_version.py
+++ b/ipyleaflet/_version.py
@@ -1,4 +1,4 @@
-version_info = (0, 4, 0, 'final', 0)
+version_info = (0, 4, 0, 'final', 1)
 
 _specifier_ = {'alpha': 'a', 'beta': 'b', 'candidate': 'rc', 'final': ''}
 

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ log.set_verbosity(log.DEBUG)
 log.info('setup.py entered')
 log.info('$PATH=%s' % os.environ['PATH'])
 
-LONG_DESCRIPTION = 'A Jupyter widget for dynamic Leaflet maps'
+LONG_DESCRIPTION = 'Azavea\'s fork of @ellisonbg\'s ipyleaflet'
 
 def js_prerelease(command, strict=False):
     """decorator for building minified js/css prior to another command"""
@@ -119,7 +119,7 @@ with open(os.path.join(here, 'ipyleaflet', '_version.py')) as f:
     exec(f.read(), {}, version_ns)
 
 setup_args = {
-    'name': 'ipyleaflet',
+    'name': 'az-ipyleaflet',
     'version': version_ns['__version__'],
     'description': 'A Jupyter widget for dynamic Leaflet maps',
     'long_description': LONG_DESCRIPTION,


### PR DESCRIPTION
## Overview

Our PR for the side-by-side control now includes merge conflicts and an older version of leaflet that makes merging it upstream difficult. Meanwhile, setuptools and pip are locked in a ~decades-~ ~months-~ long war over [whether processing dependency links is a reasonable strategy](https://github.com/pypa/pip/issues/4187), with no end in sight. Double meanwhile, we can't install our ipyleaflet in the Raster Foundry python client without processing dependency links.

This PR prefixes the package name with an `az-` and bumps the sub-minor version.

## Testing Instructions

 * `pip install az-ipyleaflet`
